### PR TITLE
Fix TypeScript syntax error in component

### DIFF
--- a/src/components/ProjectCaseStudy.tsx
+++ b/src/components/ProjectCaseStudy.tsx
@@ -384,14 +384,13 @@ const automateDecision = async (context) => {
     };
   };
 
-      whileHover={{ scale: 1.03, y: -5 }}
-      transition={{ type: "spring", stiffness: 300, damping: 20 }}
   return (
     <>
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.6, delay: index * 0.1 }}
+        whileHover={{ scale: 1.03, y: -5 }}
         className="group relative perspective-1000"
         onMouseMove={handleMouseMove}
         onMouseEnter={() => setIsHovered(true)}


### PR DESCRIPTION
Move `whileHover` prop to `motion.div` and remove orphaned `transition` prop to fix an "Unexpected token" syntax error.